### PR TITLE
Add support for hobby.porn and PornHub

### DIFF
--- a/metadata.js
+++ b/metadata.js
@@ -17,6 +17,7 @@ export default {
         "*://fansdb.cc/*",
         "*://fansdb.xyz/*",
         "*://gayeroticvideoindex.com/*",
+        "*://hobby.porn/*",
         "*://javdb.com/*",
         "*://kemono.su/*",
         "*://onlyfans.com/*",

--- a/metadata.js
+++ b/metadata.js
@@ -40,6 +40,7 @@ export default {
         "*://www.javlibrary.com/*",
         "*://www.manyvids.com/*",
         "*://www.minnano-av.com/*",
+        "*://www.pornhub.com/*",
         "*://www.pornteengirl.com/*",
         "*://www.thenude.com/*",
         "*://xcity.jp/*",

--- a/src/stashChecker.ts
+++ b/src/stashChecker.ts
@@ -325,23 +325,17 @@ export async function runStashChecker() {
             break;
         }
         case "hobby.porn": {
-            // Necessary because on page 1 there are span[class='hidden'] containing '<Performername> -'
-            let removeHiddenElements = (e: Element) => {
-                e.querySelectorAll(".hidden").forEach(h => h.remove())
-                return e.textContent?.trim()
-            }
-
             check(Target.Performer, "a[href*='/model/']:not([href*='modelInfo'])", {
                 urlSelector: e => closestUrl(e)?.match(/\/model\/[^\/]+\/\d+$/)?.[0],
                 nameSelector: e => firstText(e)?.replace("porn", "")?.replace("videos", "")?.trim()
             });
             check(Target.Performer, "h1", { nameSelector: e => firstText(e)?.replace("Free Amateur Porn - Hobby.porn", "").split("porn videos")?.[0].trim()});
             check(Target.Performer, "#tab_info > div.model-info > div > b");
-            check(Target.Scene, "h1[itemprop='name']", {urlSelector: currentSite, titleSelector: e => firstText(e)});            
+            check(Target.Scene, "h1[itemprop='name']", {urlSelector: currentSite, titleSelector: firstText});
             check(Target.Scene, "div[class*='item item-video item-lozad'] a[href*='hobby.porn/video/'] div.title-holder", {
                 observe: true,
-                urlSelector: e => closestUrl(e),
-                titleSelector: e => removeHiddenElements(e)
+                urlSelector: closestUrl,
+                titleSelector: e => e.textContent?.trim()
             });
             break;
         }
@@ -349,7 +343,7 @@ export async function runStashChecker() {
             check(Target.Performer, "[class*='pcVideoListItem'] a[href*='/model/'], [class*='pcVideoListItem'] a[href*='/pornstar/']");
             check(Target.Performer, "h1[itemprop='name']", { urlSelector: currentSite });
             check(Target.Performer, "span.pornStarName.performerCardName, div.userCardNameBlock, span.usernameBadgesWrapper", { 
-                urlSelector: e => closestUrl(e),
+                urlSelector: closestUrl,
                 nameSelector: e => e.textContent?.trim()
             });
             check(Target.Performer, "div.modelVideosTitle, div.subHeaderOverrite > h2", {

--- a/src/stashChecker.ts
+++ b/src/stashChecker.ts
@@ -324,6 +324,27 @@ export async function runStashChecker() {
             });
             break;
         }
+        case "hobby.porn": {
+            // Necessary because on page 1 there are span[class='hidden'] containing '<Performername> -'
+            let removeHiddenElements = (e: Element) => {
+                e.querySelectorAll(".hidden").forEach(h => h.remove())
+                return e.textContent?.trim()
+            }
+
+            check(Target.Performer, "a[href*='/model/']:not([href*='modelInfo'])", {
+                urlSelector: e => closestUrl(e)?.match(/\/model\/[^\/]+\/\d+$/)?.[0],
+                nameSelector: e => firstText(e)?.replace("porn", "")?.replace("videos", "")?.trim()
+            });
+            check(Target.Performer, "h1", { nameSelector: e => firstText(e)?.replace("Free Amateur Porn - Hobby.porn", "").split("porn videos")?.[0].trim()});
+            check(Target.Performer, "#tab_info > div.model-info > div > b");
+            check(Target.Scene, "h1[itemprop='name']", {urlSelector: currentSite, titleSelector: e => firstText(e)});            
+            check(Target.Scene, "div[class*='item item-video item-lozad'] a[href*='hobby.porn/video/'] div.title-holder", {
+                observe: true,
+                urlSelector: e => closestUrl(e),
+                titleSelector: e => removeHiddenElements(e)
+            });
+            break;
+        }
         case "www.babepedia.com": {
             check(Target.Performer, "h1#babename", {urlSelector: currentSite});
             check(Target.Performer, "a[href*='/babe/']", {observe: true});

--- a/src/stashChecker.ts
+++ b/src/stashChecker.ts
@@ -345,6 +345,24 @@ export async function runStashChecker() {
             });
             break;
         }
+        case "www.pornhub.com": {
+            check(Target.Performer, "[class*='pcVideoListItem'] a[href*='/model/'], [class*='pcVideoListItem'] a[href*='/pornstar/']");
+            check(Target.Performer, "h1[itemprop='name']", { urlSelector: currentSite });
+            check(Target.Performer, "span.pornStarName.performerCardName, div.userCardNameBlock, span.usernameBadgesWrapper", { 
+                urlSelector: e => closestUrl(e),
+                nameSelector: e => e.textContent?.trim()
+            });
+            check(Target.Performer, "div.modelVideosTitle, div.subHeaderOverrite > h2", {
+                urlSelector: currentSite,
+                nameSelector: e => firstText(e)?.split("'s")?.[0].trim()
+            });
+            check(Target.Studio, "[class*='pcVideoListItem'] a[href*='/channels/']");
+            check(Target.Studio, "[id='channelsProfile'] h1", { urlSelector: currentSite });
+            check(Target.Scene, "div.videoUList span.title a[href*='/view_video.php?viewkey=']", { observe: true });
+            check(Target.Scene, "h1.title", { urlSelector: currentSite })
+            check(Target.Scene, "[class*='pcVideoListItem'] span.title a[href*='/view_video.php?viewkey=']", { observe: true })
+            break;
+        }
         case "www.babepedia.com": {
             check(Target.Performer, "h1#babename", {urlSelector: currentSite});
             check(Target.Performer, "a[href*='/babe/']", {observe: true});

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -50,6 +50,7 @@
 }
 
 .stashChecker.file {
+    position: inherit;
     margin: 0.5rem;
     padding: 0.5rem;
     background-color: var(--stash-checker-color-card);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,10 +15,25 @@ export function firstTextChild(node?: Node | undefined | null): null | undefined
     } else {
         return Array.from(node.childNodes)
             .filter(n => !["svg"].includes(n.nodeName.toLowerCase()))  // element tag exceptions
-            .filter(n => n.nodeType === Node.ELEMENT_NODE ? (n as Element).getAttribute("data-type") !== "stash-symbol" : true)  // exclude checkmark
+            .filter(n => asElement(n)?.getAttribute("data-type") !== "stash-symbol")  // exclude checkmark
+            .filter(n => isElement(n) ? !isHidden(n as Element) : true)  // exclude hidden elements
             .map(firstTextChild)
             .find(n => n);  // first truthy
     }
+}
+
+function isElement(childNode: ChildNode): boolean {
+    return childNode.nodeType === Node.ELEMENT_NODE
+}
+
+function asElement(childNode: ChildNode): Element | null {
+    if (isElement(childNode)) return childNode as Element
+    else return null
+}
+
+function isHidden(element: Element): boolean {
+    // element.computedStyleMap()?.getAll("display")?.includes("none")  // not supported yet by firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1857849)
+    return window.getComputedStyle(element).display === "none"
 }
 
 export function firstText(node?: Node | undefined | null): string | undefined {


### PR DESCRIPTION
Added performer and scene support for `hobby.porn` which contains mostly information about pornhub videos even deleted ones.

This page unfortunately contains css properties like `position`, `top`, `bottom`, `left` and more for class `.file` so I've added `position: inherit;` otherwise the `Path` div superimpose the whole dialog. This shouldn't cause any issues on the other websites.