### PR TITLE
Add support for brazzers.com

### DIFF
--- a/metadata.js
+++ b/metadata.js
@@ -12,6 +12,7 @@ export default {
     license: 'MIT',
     match: [
         "*://adultanime.dbsearch.net/*",
+        "*://www.brazzers.com/*",
         "*://coomer.su/*",
         "*://erommdtube.com/*",
         "*://fansdb.cc/*",

--- a/src/stashChecker.ts
+++ b/src/stashChecker.ts
@@ -324,6 +324,19 @@ export async function runStashChecker() {
             });
             break;
         }
+        case "www.brazzers.com": {
+            check(Target.Scene, "h2[class='sc-1b6bgon-3 iTXrhy font-secondary']", {
+                observe: true,
+                urlSelector: currentSite
+            });
+            check(Target.Scene, "a[href*='/video/'", {observe: true});
+            check(Target.Performer, "h2[class='sc-ebvhsz-1 fLnSSs font-secondary']", {
+                observe: true,
+                urlSelector: currentSite
+            });
+            check(Target.Performer, "a[href*='/pornstar/'", {observe: true});
+            break;
+        }
         case "hobby.porn": {
             check(Target.Performer, "a[href*='/model/']:not([href*='modelInfo'])", {
                 urlSelector: e => closestUrl(e)?.match(/\/model\/[^\/]+\/\d+$/)?.[0],
@@ -417,6 +430,7 @@ export async function runStashChecker() {
                 titleSelector: null,
                 nameSelector: null
             }
+
             // noinspection Annotator
             function findId(string?: string): undefined | string {
                 return string?.match(/\p{Hex}{8}-\p{Hex}{4}-\p{Hex}{4}-\p{Hex}{4}-\p{Hex}{12}/u)?.[0]


### PR DESCRIPTION
I know the class selectors aren't that beautiful but they work quite well on all pages (search results, categories, pornstars).

Besides `/pornstar/` there are also `/inductee/` performers but this throws errors.
My solution was `check(Target.Performer, "a[href*='/pornstar/', a[href*='/inductee/'", {observe: true});`
Any idea why?

The performers at the scenes at the bottom on the single performer pages only contains urls for other performers. So the performer itself on his own page is just a span-title. I've ignored that.
