### PR TITLE
Add OS-independent dark-mode setting

### DIFF
--- a/src/dataTypes.ts
+++ b/src/dataTypes.ts
@@ -121,6 +121,15 @@ export enum Type {
 }
 
 /**
+ * Possible themes
+ */
+export enum Theme {
+    Light = "light",
+    Dark = "dark",
+    Device = "device"
+}
+
+/**
  * A function to select a [Type] query parameter from a given element.
  */
 export type Selector = (e: Element) => null | undefined | string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,15 @@ import {initGeneralSettings} from "./settings/general";
 import {runStashChecker} from "./stashChecker";
 import {initStatistics} from "./settings/statistics";
 import {initDisplaySettings} from "./settings/display";
+import {setTheme} from "./style/theme";
 
 (async function () {
     initSettingsWindow();
     initStatistics();
     initGeneralSettings();
     initDisplaySettings();
+
+    setTheme();
 
     await initEndpointSettings();
     await initMenu();

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {initDisplaySettings} from "./settings/display";
     initStatistics();
     initGeneralSettings();
     initDisplaySettings();
+
     await initEndpointSettings();
     await initMenu();
 

--- a/src/settings/general.ts
+++ b/src/settings/general.ts
@@ -1,5 +1,6 @@
 import {buttonDanger, getSettingsSection, newSettingsSection} from "./settings";
 import {getValue, setValue, StorageKey} from "./storage";
+import {Theme} from "../dataTypes";
 
 export enum OptionKey {
     showCheckMark = "showCheckMark",
@@ -9,19 +10,21 @@ export enum OptionKey {
     checkMark = "checkMark",
     crossMark = "crossMark",
     warningMark = "warningMark",
+    theme = "theme",
 }
 
 const defaultBooleanOptions = new Map([
     [OptionKey.showCheckMark, true],
     [OptionKey.showCrossMark, true],
     [OptionKey.showTags, true],
-    [OptionKey.showFiles, true]
+    [OptionKey.showFiles, true],
 ]);
 
 const defaultStringOptions = new Map([
     [OptionKey.checkMark, "✓"],
     [OptionKey.crossMark, "✗"],
-    [OptionKey.warningMark, "!"]
+    [OptionKey.warningMark, "!"],
+    [OptionKey.theme, Theme.Device],
 ]);
 
 export const booleanOptions: Map<OptionKey, boolean> = await getValue(StorageKey.BooleanOptions, defaultBooleanOptions)
@@ -47,6 +50,7 @@ function populateGeneralSection(generalSection: HTMLElement) {
     tooltipSettings.append(
         checkBox(OptionKey.showTags, "Show tags"),
         checkBox(OptionKey.showFiles, "Show files"),
+        selectMenu(OptionKey.theme, "Theme", [Theme.Light, Theme.Dark, Theme.Device]),
     );
     generalSection.appendChild(tooltipSettings);
 
@@ -118,5 +122,39 @@ function charBox(key: OptionKey, label: string): HTMLElement {
 
     div.appendChild(labelElement)
     div.appendChild(inputElement)
+    return div
+}
+
+function selectMenu(key: OptionKey, label: string, options: string[]): HTMLElement {
+    let div = document.createElement("div")
+    div.classList.add("option")
+
+    let labelElement: HTMLLabelElement = document.createElement("label")
+    labelElement.htmlFor = `stashChecker-dropdown-${key}`
+    labelElement.innerHTML = label
+
+    let selectElement = document.createElement("select")
+    selectElement.id = `stashChecker-dropdown-${key}`
+    selectElement.name = key
+
+    // Set the currently selected option based on saved values
+    let currentSelection = stringOptions.get(key) ?? defaultStringOptions.get(key) ?? options[0]
+    options.forEach(option => {
+        let optionElement = document.createElement("option")
+        optionElement.value = option
+        optionElement.innerHTML = option
+        if (option === currentSelection) {
+            optionElement.selected = true
+        }
+        selectElement.appendChild(optionElement)
+    })
+
+    selectElement.addEventListener("change", () => {
+        stringOptions.set(key, selectElement.value)
+        void setValue(StorageKey.StringOptions, stringOptions)
+    });
+
+    div.appendChild(labelElement)
+    div.appendChild(selectElement)
     return div
 }

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -2,6 +2,7 @@ import {clearObservers} from "../observer";
 import {clearSymbols} from "../tooltip/tooltip";
 import {runStashChecker} from "../stashChecker";
 import {updateStatistics} from "./statistics";
+import {setTheme} from "../style/theme";
 
 export function initSettingsWindow() {
     let settingsModal = document.createElement("div");
@@ -64,6 +65,7 @@ function closeSettingsWindow(this: HTMLElement, event: MouseEvent) {
         this.style.display = "none";
         clearObservers()
         clearSymbols()
+        setTheme()
         void runStashChecker()
     }
 }

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -11,18 +11,16 @@
     --stash-checker-color-card: #f2f2f2;
 }
 
-@media (prefers-color-scheme: dark) {
-    :root {
-        --stash-checker-color-text: #e0e0e0;
-        --stash-checker-color-text-light: #707070;
-        --stash-checker-color-link-visited: #c7c7c7;
-        --stash-checker-color-link-hover: #f2f2f2;
-        --stash-checker-color-link-active: #039;
-        --stash-checker-color-border: #5a5a5a;
-        --stash-checker-color-border-light: #707070;
-        --stash-checker-color-bg: #202020;
-        --stash-checker-color-card: #464646;
-    }
+.dark-mode {
+    --stash-checker-color-text: #e0e0e0;
+    --stash-checker-color-text-light: #707070;
+    --stash-checker-color-link-visited: #c7c7c7;
+    --stash-checker-color-link-hover: #f2f2f2;
+    --stash-checker-color-link-active: #039;
+    --stash-checker-color-border: #5a5a5a;
+    --stash-checker-color-border-light: #707070;
+    --stash-checker-color-bg: #202020;
+    --stash-checker-color-card: #464646;
 }
 
 .stashChecker {
@@ -74,8 +72,8 @@
     height: 100%;
     overflow: hidden auto;
     overscroll-behavior: contain;
-    background-color: rgb(0,0,0); // fallback
-    background-color: rgba(0,0,0,0.4);
+    background-color: rgb(0, 0, 0); // fallback
+    background-color: rgba(0, 0, 0, 0.4);
 }
 
 .stashChecker.settings {
@@ -184,6 +182,10 @@
     background-color: var(--stash-checker-color-bg);
 }
 
+.stashChecker .option > select {
+    margin-left: 0.5rem;
+}
+
 .stashChecker .option > label {
 }
 
@@ -207,30 +209,36 @@
     font-size: 1rem;
     line-height: 1.5;
     border-radius: .25rem;
-    transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+    transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out;
 }
+
 .stashChecker.btn:not(:disabled):not(.disabled) {
     cursor: pointer;
 }
+
 .stashChecker.btn:hover {
     color: #212529;
     text-decoration: none;
 }
+
 .stashChecker.btn-primary {
     color: #fff;
     background-color: #137cbd;
     border-color: #137cbd;
 }
+
 .stashChecker.btn-primary:hover {
     color: #fff;
     background-color: #10659a;
     border-color: #0e5e8f;
 }
+
 .stashChecker.btn-danger {
     color: #fff;
     background-color: #db3737;
     border-color: #db3737;
 }
+
 .stashChecker.btn-danger:hover {
     color: #fff;
     background-color: #c82424;
@@ -240,15 +248,19 @@
 .stashChecker.tooltip a:link {
     color: var(--stash-checker-color-text);
 }
+
 .stashChecker.tooltip a:visited {
     color: var(--stash-checker-color-link-visited);
 }
+
 .stashChecker.tooltip a:hover {
     color: var(--stash-checker-color-link-hover);
 }
+
 .stashChecker.tooltip a:active {
     color: var(--stash-checker-color-link-active);
 }
+
 .stashChecker.tooltip hr {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -11,7 +11,7 @@
     --stash-checker-color-card: #f2f2f2;
 }
 
-.dark-mode {
+.stashChecker-dark-mode {
     --stash-checker-color-text: #e0e0e0;
     --stash-checker-color-text-light: #707070;
     --stash-checker-color-link-visited: #c7c7c7;

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -1,0 +1,26 @@
+import {OptionKey, stringOptions} from "../settings/general";
+import {Theme} from "../dataTypes";
+
+export function setTheme() {
+
+    const osSetting = window.matchMedia("(prefers-color-scheme: dark)");
+
+    function toggleDarkMode(state: boolean | undefined) {
+        document.documentElement.classList.toggle("dark-mode", state);
+    }
+
+    switch (stringOptions.get(OptionKey.theme)) {
+        case Theme.Light:
+            toggleDarkMode(false)
+            break;
+        case Theme.Dark:
+            toggleDarkMode(true)
+            break;
+        case Theme.Device:
+        default:
+            toggleDarkMode(osSetting.matches);
+            break;
+    }
+}
+
+window.addEventListener("DOMContentLoaded", setTheme);

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -6,7 +6,7 @@ export function setTheme() {
     const osSetting = window.matchMedia("(prefers-color-scheme: dark)");
 
     function toggleDarkMode(state: boolean | undefined) {
-        document.documentElement.classList.toggle("dark-mode", state);
+        document.documentElement.classList.toggle("stashChecker-dark-mode", state);
     }
 
     switch (stringOptions.get(OptionKey.theme)) {
@@ -22,5 +22,3 @@ export function setTheme() {
             break;
     }
 }
-
-window.addEventListener("DOMContentLoaded", setTheme);

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -13,6 +13,7 @@ import {bytesToReadable, firstTextChild, secondsToReadable, typeToString} from "
 import {booleanOptions, OptionKey, stringOptions} from "../settings/general";
 import {StashQuery, StashQueryClass} from "./stashQuery";
 import tippy, {ReferenceElement} from "tippy.js";
+import {setTheme} from "../style/theme";
 
 /**
  * find existing symbol span recursively, undefined if none available
@@ -67,7 +68,7 @@ function formatFileData(file: StashFile, queries: StashQuery[], target: Target, 
     return `<div class='stashChecker file'>${text}</div>`
 }
 
-function formatTagPill(tag: {id: string, name: string}): string {
+function formatTagPill(tag: { id: string, name: string }): string {
     return `<span class='stashChecker tag'>${tag.name}</span>`;
 }
 
@@ -152,7 +153,7 @@ export function prefixSymbol(
     let queryTypes = [type];
     // Specific query for this result
     let baseUrl = endpoint.url.replace(/\/graphql\/?$/, "");
-    let query: StashQuery = { endpoint: endpoint.name, baseUrl, types: queryTypes };
+    let query: StashQuery = {endpoint: endpoint.name, baseUrl, types: queryTypes};
     // Add query, endpoint and display options to each new entry
     data.forEach((entry: StashEntry) => {
         entry.queries = [query]
@@ -197,7 +198,7 @@ export function prefixSymbol(
         }
         symbol.style.color = "red";
         tooltip = `${targetReadable} not in Stash<br>`;
-    } else if(new Set(data.map(e => e.endpoint)).size < data.length) {
+    } else if (new Set(data.map(e => e.endpoint)).size < data.length) {
         symbol.setAttribute("data-symbol", StashSymbol.Warning);
         symbol.innerHTML = `${stringOptions.get(OptionKey.warningMark)!}&nbsp;`;
         symbol.style.color = "orange";
@@ -216,6 +217,8 @@ export function prefixSymbol(
     tooltip += `Queries: ${queryTypes.map(type => typeToString.get(type)).join(", ")}`;
     // List of results
     tooltip += data.map(entry => formatEntryData(entry, target, queryTypes.length)).join("");
+
+    setTheme();
 
     // Set tooltip content on symbol
     let tooltipWindow = document.createElement("div");

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -13,7 +13,6 @@ import {bytesToReadable, firstTextChild, secondsToReadable, typeToString} from "
 import {booleanOptions, OptionKey, stringOptions} from "../settings/general";
 import {StashQuery, StashQueryClass} from "./stashQuery";
 import tippy, {ReferenceElement} from "tippy.js";
-import {setTheme} from "../style/theme";
 
 /**
  * find existing symbol span recursively, undefined if none available
@@ -217,8 +216,6 @@ export function prefixSymbol(
     tooltip += `Queries: ${queryTypes.map(type => typeToString.get(type)).join(", ")}`;
     // List of results
     tooltip += data.map(entry => formatEntryData(entry, target, queryTypes.length)).join("");
-
-    setTheme();
 
     // Set tooltip content on symbol
     let tooltipWindow = document.createElement("div");


### PR DESCRIPTION
The `prefers-color-scheme: dark` #14 never worked in my browser and I'm always feeling annoyed when software forces the dark-light-mode based on my OS (or browser) settings.

I've added a new theme-setting includes `light`, `dark` and `device` options. Light and dark overrides the OS setting whereas device takes either the OS scheme or the default stash-checker mode (light). Tested via Chrome DevTools Rendering color-scheme emulation.

Implementation based on [Dark Mode - The prefers-color-scheme Website Tutorial](https://www.ditdot.hr/en/dark-mode-website-tutorial)

