### PR TITLE
Add visual effect for scene covers based on opacity value in user settings

### DIFF
--- a/metadata.js
+++ b/metadata.js
@@ -12,6 +12,7 @@ export default {
     license: 'MIT',
     match: [
         "*://adultanime.dbsearch.net/*",
+        "*://www.brazzers.com/*",
         "*://coomer.su/*",
         "*://erommdtube.com/*",
         "*://fansdb.cc/*",

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,6 +1,6 @@
 import {prefixSymbol} from "./tooltip/tooltip";
 import {stashEndpoints} from "./settings/endpoints";
-import {firstText, hasKanji} from "./utils";
+import {firstText, hasKanji, nakedDomain} from "./utils";
 import {CheckOptions, CustomDisplayRule, DataField, DisplayOptions, StashEndpoint, Target, Type} from "./dataTypes";
 import {request} from "./request";
 import {booleanOptions, OptionKey} from "./settings/general";
@@ -19,7 +19,7 @@ const supportedDataFields = new Map<Target, DataField[]>([
     [Target.Performer, [DataField.Id, DataField.Name, DataField.Disambiguation, DataField.Favorite, DataField.AliasList, DataField.Birthdate, DataField.HeightCm, DataField.Tags]],
     [Target.Gallery, [DataField.Id, DataField.Title, DataField.Date, DataField.Tags, DataField.Files]],
     [Target.Movie, [DataField.Id, DataField.Name, DataField.Date]],
-    [Target.Studio,[DataField.Id, DataField.Name, DataField.Aliases]],
+    [Target.Studio, [DataField.Id, DataField.Name, DataField.Aliases]],
     [Target.Tag, [DataField.Id, DataField.Name]],
 ]);
 
@@ -62,6 +62,9 @@ async function queryStash(
     switch (type) {
         case Type.StashId:
             filter = `stash_id_endpoint:{endpoint:"${encodeURIComponent(stashIdEndpoint)}",stash_id:"${encodeURIComponent(queryString)}",modifier:EQUALS}${customFilter}`;
+            break;
+        case Type.Url:
+            filter = `${type}:{value:"""${encodeURIComponent(queryString)}""",modifier:INCLUDES}${customFilter}`;
             break;
         default:
             filter = `${type}:{value:"""${encodeURIComponent(queryString)}""",modifier:EQUALS}${customFilter}`;
@@ -132,6 +135,7 @@ async function checkElement(
     if (urlSelector) {
         let url = urlSelector(element)
         if (url) {
+            url = nakedDomain(url);
             console.debug(`URL: ${url}`);
             await queryStash(url, (...args) => prefixSymbol(displayElement!, ...args, display), target, Type.Url, customFilter, stashIdEndpoint);
         } else {

--- a/src/dataTypes.ts
+++ b/src/dataTypes.ts
@@ -104,8 +104,10 @@ export function readable(target: Target): string {
 
 export function readablePlural(target: Target): string {
     switch (target) {
-        case Target.Gallery: return "Galleries";
-        default: return readable(target) + "s";
+        case Target.Gallery:
+            return "Galleries";
+        default:
+            return readable(target) + "s";
     }
 }
 
@@ -124,9 +126,13 @@ export enum Type {
  * Possible themes
  */
 export enum Theme {
-    Light = "light",
-    Dark = "dark",
-    Device = "device"
+    Light = "Light",
+    Dark = "Dark",
+    Device = "Device"
+}
+
+export function getAllThemes(): string[] {
+    return [Theme.Light, Theme.Dark, Theme.Device];
 }
 
 /**

--- a/src/dataTypes.ts
+++ b/src/dataTypes.ts
@@ -121,6 +121,15 @@ export enum Type {
 }
 
 /**
+ * Possible themes
+ */
+export enum Theme {
+    Light = "light",
+    Dark = "dark",
+    Device = "device"
+}
+
+/**
  * A function to select a [Type] query parameter from a given element.
  */
 export type Selector = (e: Element) => null | undefined | string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,16 @@ import {initGeneralSettings} from "./settings/general";
 import {runStashChecker} from "./stashChecker";
 import {initStatistics} from "./settings/statistics";
 import {initDisplaySettings} from "./settings/display";
+import {setTheme} from "./style/theme";
 
 (async function () {
     initSettingsWindow();
     initStatistics();
     initGeneralSettings();
     initDisplaySettings();
+
+    setTheme();
+
     await initEndpointSettings();
     await initMenu();
 

--- a/src/settings/general.ts
+++ b/src/settings/general.ts
@@ -1,5 +1,6 @@
 import {buttonDanger, getSettingsSection, newSettingsSection} from "./settings";
 import {getValue, setValue, StorageKey} from "./storage";
+import {Theme} from "../dataTypes";
 
 export enum OptionKey {
     showCheckMark = "showCheckMark",
@@ -9,19 +10,21 @@ export enum OptionKey {
     checkMark = "checkMark",
     crossMark = "crossMark",
     warningMark = "warningMark",
+    theme = "theme",
 }
 
 const defaultBooleanOptions = new Map([
     [OptionKey.showCheckMark, true],
     [OptionKey.showCrossMark, true],
     [OptionKey.showTags, true],
-    [OptionKey.showFiles, true]
+    [OptionKey.showFiles, true],
 ]);
 
 const defaultStringOptions = new Map([
     [OptionKey.checkMark, "✓"],
     [OptionKey.crossMark, "✗"],
-    [OptionKey.warningMark, "!"]
+    [OptionKey.warningMark, "!"],
+    [OptionKey.theme, Theme.Device],
 ]);
 
 export const booleanOptions: Map<OptionKey, boolean> = await getValue(StorageKey.BooleanOptions, defaultBooleanOptions)
@@ -47,6 +50,7 @@ function populateGeneralSection(generalSection: HTMLElement) {
     tooltipSettings.append(
         checkBox(OptionKey.showTags, "Show tags"),
         checkBox(OptionKey.showFiles, "Show files"),
+        selectMenu(OptionKey.theme, "Theme", [Theme.Light, Theme.Dark, Theme.Device]),
     );
     generalSection.appendChild(tooltipSettings);
 
@@ -118,5 +122,39 @@ function charBox(key: OptionKey, label: string): HTMLElement {
 
     div.appendChild(labelElement)
     div.appendChild(inputElement)
+    return div
+}
+
+function selectMenu(key: OptionKey, label: string, options: string[]): HTMLElement {
+    let div = document.createElement("div")
+    div.classList.add("option")
+
+    let labelElement: HTMLLabelElement = document.createElement("label")
+    labelElement.htmlFor = `stashChecker-dropdown-${key}`
+    labelElement.innerHTML = label
+
+    let selectElement = document.createElement("select")
+    selectElement.id = `stashChecker-dropdown-${key}`
+    selectElement.name = key
+
+    // Set the currently selected option based on saved values
+    let currentSelection = stringOptions.get(key) ?? defaultStringOptions.get(key) ?? options[0]
+    options.forEach(option => {
+        let optionElement = document.createElement("option")
+        optionElement.value = option
+        optionElement.innerHTML = option
+        if (option === currentSelection) {
+            optionElement.selected = true
+        }
+        selectElement.appendChild(optionElement)
+    })
+
+    selectElement.addEventListener("change", () => {
+        stringOptions.set(key, selectElement.value)
+        void setValue(StorageKey.StringOptions, stringOptions)
+    });
+
+    div.appendChild(labelElement)
+    div.appendChild(selectElement)
     return div
 }

--- a/src/settings/general.ts
+++ b/src/settings/general.ts
@@ -11,6 +11,8 @@ export enum OptionKey {
     crossMark = "crossMark",
     warningMark = "warningMark",
     theme = "theme",
+    opacityCheckMark = "opacityCheckMark",
+    opacityCrossMark = "opacityCrossMark",
 }
 
 const defaultBooleanOptions = new Map([
@@ -25,13 +27,17 @@ const defaultStringOptions = new Map([
     [OptionKey.crossMark, "✗"],
     [OptionKey.warningMark, "!"],
     [OptionKey.theme, Theme.Device],
+    [OptionKey.opacityCheckMark, "100"],
+    [OptionKey.opacityCrossMark, "100"],
 ]);
 
 export const booleanOptions: Map<OptionKey, boolean> = await getValue(StorageKey.BooleanOptions, defaultBooleanOptions)
 export const stringOptions: Map<OptionKey, string> = await getValue(StorageKey.StringOptions, defaultStringOptions)
 
 export function initGeneralSettings() {
-    let generalSection = newSettingsSection("general", "General")
+    let description = "Scene cover opacity can change the visual effect of the scene covers. You can darken both the found and the missing elements. " +
+        "If the value is 100%, no changes are made."
+    let generalSection = newSettingsSection("general", "General", description);
     populateGeneralSection(generalSection)
 }
 

--- a/src/settings/general.ts
+++ b/src/settings/general.ts
@@ -1,6 +1,7 @@
 import {buttonDanger, getSettingsSection, newSettingsSection} from "./settings";
 import {getValue, setValue, StorageKey} from "./storage";
-import {Theme} from "../dataTypes";
+import {getAllThemes, Theme} from "../dataTypes";
+import {rangeStr} from "../utils";
 
 export enum OptionKey {
     showCheckMark = "showCheckMark",
@@ -11,6 +12,7 @@ export enum OptionKey {
     crossMark = "crossMark",
     warningMark = "warningMark",
     theme = "theme",
+    opacityScenes = "opacityScenes",
     opacityCheckMark = "opacityCheckMark",
     opacityCrossMark = "opacityCrossMark",
 }
@@ -20,6 +22,7 @@ const defaultBooleanOptions = new Map([
     [OptionKey.showCrossMark, true],
     [OptionKey.showTags, true],
     [OptionKey.showFiles, true],
+    [OptionKey.opacityScenes, false]
 ]);
 
 const defaultStringOptions = new Map([
@@ -56,9 +59,17 @@ function populateGeneralSection(generalSection: HTMLElement) {
     tooltipSettings.append(
         checkBox(OptionKey.showTags, "Show tags"),
         checkBox(OptionKey.showFiles, "Show files"),
-        selectMenu(OptionKey.theme, "Theme", [Theme.Light, Theme.Dark, Theme.Device]),
+        selectMenu(OptionKey.theme, "Theme", getAllThemes()),
     );
     generalSection.appendChild(tooltipSettings);
+
+    let sceneSettings = fieldSet("scene-settings", "Scene");
+    sceneSettings.append(
+        checkBox(OptionKey.opacityScenes, "Modify cover opacity"),
+        selectMenu(OptionKey.opacityCheckMark, "Check mark", rangeStr(0, 100, 10), '%'),
+        selectMenu(OptionKey.opacityCrossMark, "Cross mark", rangeStr(0, 100, 10), '%'),
+    );
+    generalSection.appendChild(sceneSettings);
 
     let defaultButton = fieldSet("default-button", "Default Settings");
     let div = document.createElement("div")
@@ -131,7 +142,7 @@ function charBox(key: OptionKey, label: string): HTMLElement {
     return div
 }
 
-function selectMenu(key: OptionKey, label: string, options: string[]): HTMLElement {
+function selectMenu(key: OptionKey, label: string, options: string[], unit?: string): HTMLElement {
     let div = document.createElement("div")
     div.classList.add("option")
 
@@ -148,7 +159,7 @@ function selectMenu(key: OptionKey, label: string, options: string[]): HTMLEleme
     options.forEach(option => {
         let optionElement = document.createElement("option")
         optionElement.value = option
-        optionElement.innerHTML = option
+        optionElement.innerHTML = option.concat(unit ?? '');
         if (option === currentSelection) {
             optionElement.selected = true
         }

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -2,6 +2,7 @@ import {clearObservers} from "../observer";
 import {clearSymbols} from "../tooltip/tooltip";
 import {runStashChecker} from "../stashChecker";
 import {updateStatistics} from "./statistics";
+import {setTheme} from "../style/theme";
 
 export function initSettingsWindow() {
     let settingsModal = document.createElement("div");
@@ -64,6 +65,7 @@ function closeSettingsWindow(this: HTMLElement, event: MouseEvent) {
         this.style.display = "none";
         clearObservers()
         clearSymbols()
+        setTheme()
         void runStashChecker()
     }
 }

--- a/src/stashChecker.ts
+++ b/src/stashChecker.ts
@@ -324,6 +324,19 @@ export async function runStashChecker() {
             });
             break;
         }
+        case "www.brazzers.com": {
+            check(Target.Scene, "h2[class='sc-1b6bgon-3 iTXrhy font-secondary']", {
+                observe: true,
+                urlSelector: currentSite
+            });
+            check(Target.Scene, "a[href*='/video/'", {observe: true});
+            check(Target.Performer, "h2[class='sc-ebvhsz-1 fLnSSs font-secondary']", {
+                observe: true,
+                urlSelector: currentSite
+            });
+            check(Target.Performer, "a[href*='/pornstar/'", {observe: true});
+            break;
+        }
         case "hobby.porn": {
             check(Target.Performer, "a[href*='/model/']:not([href*='modelInfo'])", {
                 urlSelector: e => closestUrl(e)?.match(/\/model\/[^\/]+\/\d+$/)?.[0],

--- a/src/style/main.scss
+++ b/src/style/main.scss
@@ -11,18 +11,16 @@
     --stash-checker-color-card: #f2f2f2;
 }
 
-@media (prefers-color-scheme: dark) {
-    :root {
-        --stash-checker-color-text: #e0e0e0;
-        --stash-checker-color-text-light: #707070;
-        --stash-checker-color-link-visited: #c7c7c7;
-        --stash-checker-color-link-hover: #f2f2f2;
-        --stash-checker-color-link-active: #039;
-        --stash-checker-color-border: #5a5a5a;
-        --stash-checker-color-border-light: #707070;
-        --stash-checker-color-bg: #202020;
-        --stash-checker-color-card: #464646;
-    }
+.stashChecker-dark-mode {
+    --stash-checker-color-text: #e0e0e0;
+    --stash-checker-color-text-light: #707070;
+    --stash-checker-color-link-visited: #c7c7c7;
+    --stash-checker-color-link-hover: #f2f2f2;
+    --stash-checker-color-link-active: #039;
+    --stash-checker-color-border: #5a5a5a;
+    --stash-checker-color-border-light: #707070;
+    --stash-checker-color-bg: #202020;
+    --stash-checker-color-card: #464646;
 }
 
 .stashChecker {
@@ -74,8 +72,8 @@
     height: 100%;
     overflow: hidden auto;
     overscroll-behavior: contain;
-    background-color: rgb(0,0,0); // fallback
-    background-color: rgba(0,0,0,0.4);
+    background-color: rgb(0, 0, 0); // fallback
+    background-color: rgba(0, 0, 0, 0.4);
 }
 
 .stashChecker.settings {
@@ -184,6 +182,10 @@
     background-color: var(--stash-checker-color-bg);
 }
 
+.stashChecker .option > select {
+    margin-left: 0.5rem;
+}
+
 .stashChecker .option > label {
 }
 
@@ -207,30 +209,36 @@
     font-size: 1rem;
     line-height: 1.5;
     border-radius: .25rem;
-    transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
+    transition: color .15s ease-in-out, background-color .15s ease-in-out, border-color .15s ease-in-out, box-shadow .15s ease-in-out;
 }
+
 .stashChecker.btn:not(:disabled):not(.disabled) {
     cursor: pointer;
 }
+
 .stashChecker.btn:hover {
     color: #212529;
     text-decoration: none;
 }
+
 .stashChecker.btn-primary {
     color: #fff;
     background-color: #137cbd;
     border-color: #137cbd;
 }
+
 .stashChecker.btn-primary:hover {
     color: #fff;
     background-color: #10659a;
     border-color: #0e5e8f;
 }
+
 .stashChecker.btn-danger {
     color: #fff;
     background-color: #db3737;
     border-color: #db3737;
 }
+
 .stashChecker.btn-danger:hover {
     color: #fff;
     background-color: #c82424;
@@ -240,15 +248,19 @@
 .stashChecker.tooltip a:link {
     color: var(--stash-checker-color-text);
 }
+
 .stashChecker.tooltip a:visited {
     color: var(--stash-checker-color-link-visited);
 }
+
 .stashChecker.tooltip a:hover {
     color: var(--stash-checker-color-link-hover);
 }
+
 .stashChecker.tooltip a:active {
     color: var(--stash-checker-color-link-active);
 }
+
 .stashChecker.tooltip hr {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -1,0 +1,24 @@
+import {OptionKey, stringOptions} from "../settings/general";
+import {Theme} from "../dataTypes";
+
+export function setTheme() {
+
+    const osSetting = window.matchMedia("(prefers-color-scheme: dark)");
+
+    function toggleDarkMode(state: boolean | undefined) {
+        document.documentElement.classList.toggle("stashChecker-dark-mode", state);
+    }
+
+    switch (stringOptions.get(OptionKey.theme)) {
+        case Theme.Light:
+            toggleDarkMode(false)
+            break;
+        case Theme.Dark:
+            toggleDarkMode(true)
+            break;
+        case Theme.Device:
+        default:
+            toggleDarkMode(osSetting.matches);
+            break;
+    }
+}

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -182,7 +182,7 @@ function stashSymbol(): HTMLSpanElement {
 
 /**
  * Prepends depending on the data the checkmark or cross to the selected element.
- * Also populates tooltip window and sets the opacity of the cover based on user settings.
+ * Also populates tooltip window and sets the opacity of the scene covers based on user settings (optional).
  */
 export function prefixSymbol(
     element: Element,
@@ -269,8 +269,8 @@ export function prefixSymbol(
     tooltipWindow.tabIndex = 0;
     (symbol as ReferenceElement)._tippy?.setContent(tooltipWindow);
 
-    // Set opacity of scene cover
-    if ((target === Target.Scene)) {
+    // Set opacity of scene cover if functionality is enabled
+    if ((target === Target.Scene) && (booleanOptions.get(OptionKey.opacityScenes) ?? false)) {
 
         let opacityCheckMarkValue = parseInt(stringOptions.get(OptionKey.opacityCheckMark) ?? '-1');
         let opacityCrossMarkValue = parseInt(stringOptions.get(OptionKey.opacityCrossMark) ?? '-1');

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -268,7 +268,6 @@ export function prefixSymbol(
     tooltipWindow.innerHTML = tooltip;
     tooltipWindow.tabIndex = 0;
     (symbol as ReferenceElement)._tippy?.setContent(tooltipWindow);
-}
 
     // Set opacity of scene cover if functionality is enabled
     if ((target === Target.Scene) && (booleanOptions.get(OptionKey.opacityScenes) ?? false)) {

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -67,7 +67,7 @@ function formatFileData(file: StashFile, queries: StashQuery[], target: Target, 
     return `<div class='stashChecker file'>${text}</div>`
 }
 
-function formatTagPill(tag: {id: string, name: string}): string {
+function formatTagPill(tag: { id: string, name: string }): string {
     return `<span class='stashChecker tag'>${tag.name}</span>`;
 }
 
@@ -152,7 +152,7 @@ export function prefixSymbol(
     let queryTypes = [type];
     // Specific query for this result
     let baseUrl = endpoint.url.replace(/\/graphql\/?$/, "");
-    let query: StashQuery = { endpoint: endpoint.name, baseUrl, types: queryTypes };
+    let query: StashQuery = {endpoint: endpoint.name, baseUrl, types: queryTypes};
     // Add query, endpoint and display options to each new entry
     data.forEach((entry: StashEntry) => {
         entry.queries = [query]
@@ -197,7 +197,7 @@ export function prefixSymbol(
         }
         symbol.style.color = "red";
         tooltip = `${targetReadable} not in Stash<br>`;
-    } else if(new Set(data.map(e => e.endpoint)).size < data.length) {
+    } else if (new Set(data.map(e => e.endpoint)).size < data.length) {
         symbol.setAttribute("data-symbol", StashSymbol.Warning);
         symbol.innerHTML = `${stringOptions.get(OptionKey.warningMark)!}&nbsp;`;
         symbol.style.color = "orange";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,6 +96,20 @@ export function titleCase(text: string): string {
     return text.split(" ").map(n => capitalized(n)).join(" ");
 }
 
+export function isBetween(value: number | undefined | null, min: number, max: number): boolean {
+    if (value === undefined || value === null) {
+        return false;
+    }
+    return value >= min && value <= max;
+}
+
+export function percentToDecimal(percent: number | undefined | null, defaultValue: number): number {
+    if (percent == null || isNaN(percent)) {
+        return defaultValue;
+    }
+    return percent / 100;
+}
+
 export function nakedDomain(url: string): string {
     const regex = /^(https?:\/\/)?(www\.)?/i;
     return url.replace(regex, '');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,6 +110,18 @@ export function percentToDecimal(percent: number | undefined | null, defaultValu
     return percent / 100;
 }
 
+export function range(first: number, last: number, step: number): number[] {
+    const rangeArray: number[] = [];
+    for (let i = first; i <= last; i += step) {
+        rangeArray.push(i);
+    }
+    return rangeArray;
+}
+
+export function rangeStr(first: number, last: number, step: number): string[] {
+    return range(first, last, step).map(number => number.toString());
+}
+
 export function nakedDomain(url: string): string {
     const regex = /^(https?:\/\/)?(www\.)?/i;
     return url.replace(regex, '');

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,7 +41,7 @@ export function firstText(node?: Node | undefined | null): string | undefined {
 }
 
 export function allText(node?: Node | undefined | null): string[] {
-    let words: any[] =  node ? Array.from(node.childNodes)
+    let words: any[] = node ? Array.from(node.childNodes)
         .flatMap(n => n.nodeType == Node.TEXT_NODE ? [n.textContent] : allText(n))
         .filter((s: string | null) => s) : []
     return words;
@@ -94,6 +94,11 @@ export function capitalized(word: string): string {
 
 export function titleCase(text: string): string {
     return text.split(" ").map(n => capitalized(n)).join(" ");
+}
+
+export function nakedDomain(url: string): string {
+    const regex = /^(https?:\/\/)?(www\.)?/i;
+    return url.replace(regex, '');
 }
 
 export function interleave<T extends Node>(array: T[], between: T): T[] {


### PR DESCRIPTION
Enhanced initial functionality for scene cover brightness for matching and/or missing scenes. It works for every website which uses `img` tag close to our check/cross mark symbol. Performance isn't an issue anymore and also works with `observe: true` quite well.

This technically covers and solves #34 

Following features will come soon:

- Replace opacity input fields with more user-friendly select menu (already implemented and used at #47)
- CheckOptions.sceneCardSelector to define whole scene cards for each website
- Remove scene cards on 0% capacity (only for realizable websites)
- Injected switch for "Only missing scenes" at StashDB (configurable in settings) comparable to 'capacity at 0%'
   - Scenes page
   - Performer/Scenes
   - Studio page
   - Studio page/Performers
   - Tag/Scenes