### PR TITLE
Add visual effect for scene covers based on opacity value in user settings

### DIFF
--- a/src/dataTypes.ts
+++ b/src/dataTypes.ts
@@ -104,8 +104,10 @@ export function readable(target: Target): string {
 
 export function readablePlural(target: Target): string {
     switch (target) {
-        case Target.Gallery: return "Galleries";
-        default: return readable(target) + "s";
+        case Target.Gallery:
+            return "Galleries";
+        default:
+            return readable(target) + "s";
     }
 }
 
@@ -124,9 +126,13 @@ export enum Type {
  * Possible themes
  */
 export enum Theme {
-    Light = "light",
-    Dark = "dark",
-    Device = "device"
+    Light = "Light",
+    Dark = "Dark",
+    Device = "Device"
+}
+
+export function getAllThemes(): string[] {
+    return [Theme.Light, Theme.Dark, Theme.Device];
 }
 
 /**

--- a/src/settings/general.ts
+++ b/src/settings/general.ts
@@ -66,8 +66,8 @@ function populateGeneralSection(generalSection: HTMLElement) {
     let sceneSettings = fieldSet("scene-settings", "Scene");
     sceneSettings.append(
         checkBox(OptionKey.opacityScenes, "Modify cover opacity"),
-        selectMenu(OptionKey.opacityCheckMark, "Check mark", rangeStr(0, 100, 10), '%'),
-        selectMenu(OptionKey.opacityCrossMark, "Cross mark", rangeStr(0, 100, 10), '%'),
+        selectMenu(OptionKey.opacityCheckMark, "Check mark", rangeStr(10, 100, 10), '%'),
+        selectMenu(OptionKey.opacityCrossMark, "Cross mark", rangeStr(10, 100, 10), '%'),
     );
     generalSection.appendChild(sceneSettings);
 

--- a/src/settings/general.ts
+++ b/src/settings/general.ts
@@ -1,6 +1,7 @@
 import {buttonDanger, getSettingsSection, newSettingsSection} from "./settings";
 import {getValue, setValue, StorageKey} from "./storage";
-import {Theme} from "../dataTypes";
+import {getAllThemes, Theme} from "../dataTypes";
+import {rangeStr} from "../utils";
 
 export enum OptionKey {
     showCheckMark = "showCheckMark",
@@ -11,6 +12,9 @@ export enum OptionKey {
     crossMark = "crossMark",
     warningMark = "warningMark",
     theme = "theme",
+    opacityScenes = "opacityScenes",
+    opacityCheckMark = "opacityCheckMark",
+    opacityCrossMark = "opacityCrossMark",
 }
 
 const defaultBooleanOptions = new Map([
@@ -18,6 +22,7 @@ const defaultBooleanOptions = new Map([
     [OptionKey.showCrossMark, true],
     [OptionKey.showTags, true],
     [OptionKey.showFiles, true],
+    [OptionKey.opacityScenes, false]
 ]);
 
 const defaultStringOptions = new Map([
@@ -25,13 +30,17 @@ const defaultStringOptions = new Map([
     [OptionKey.crossMark, "✗"],
     [OptionKey.warningMark, "!"],
     [OptionKey.theme, Theme.Device],
+    [OptionKey.opacityCheckMark, "100"],
+    [OptionKey.opacityCrossMark, "100"],
 ]);
 
 export const booleanOptions: Map<OptionKey, boolean> = await getValue(StorageKey.BooleanOptions, defaultBooleanOptions)
 export const stringOptions: Map<OptionKey, string> = await getValue(StorageKey.StringOptions, defaultStringOptions)
 
 export function initGeneralSettings() {
-    let generalSection = newSettingsSection("general", "General")
+    let description = "Scene cover opacity can change the visual effect of the scene covers. You can darken both the found and the missing elements. " +
+        "If the value is 100%, no changes are made."
+    let generalSection = newSettingsSection("general", "General", description);
     populateGeneralSection(generalSection)
 }
 
@@ -50,9 +59,17 @@ function populateGeneralSection(generalSection: HTMLElement) {
     tooltipSettings.append(
         checkBox(OptionKey.showTags, "Show tags"),
         checkBox(OptionKey.showFiles, "Show files"),
-        selectMenu(OptionKey.theme, "Theme", [Theme.Light, Theme.Dark, Theme.Device]),
+        selectMenu(OptionKey.theme, "Theme", getAllThemes()),
     );
     generalSection.appendChild(tooltipSettings);
+
+    let sceneSettings = fieldSet("scene-settings", "Scene");
+    sceneSettings.append(
+        checkBox(OptionKey.opacityScenes, "Modify cover opacity"),
+        selectMenu(OptionKey.opacityCheckMark, "Check mark", rangeStr(0, 100, 10), '%'),
+        selectMenu(OptionKey.opacityCrossMark, "Cross mark", rangeStr(0, 100, 10), '%'),
+    );
+    generalSection.appendChild(sceneSettings);
 
     let defaultButton = fieldSet("default-button", "Default Settings");
     let div = document.createElement("div")
@@ -125,7 +142,7 @@ function charBox(key: OptionKey, label: string): HTMLElement {
     return div
 }
 
-function selectMenu(key: OptionKey, label: string, options: string[]): HTMLElement {
+function selectMenu(key: OptionKey, label: string, options: string[], unit?: string): HTMLElement {
     let div = document.createElement("div")
     div.classList.add("option")
 
@@ -142,7 +159,7 @@ function selectMenu(key: OptionKey, label: string, options: string[]): HTMLEleme
     options.forEach(option => {
         let optionElement = document.createElement("option")
         optionElement.value = option
-        optionElement.innerHTML = option
+        optionElement.innerHTML = option.concat(unit ?? '');
         if (option === currentSelection) {
             optionElement.selected = true
         }

--- a/src/tooltip/tooltip.ts
+++ b/src/tooltip/tooltip.ts
@@ -9,13 +9,13 @@ import {
     Target,
     Type
 } from "../dataTypes";
-import {bytesToReadable, firstTextChild, secondsToReadable, typeToString} from "../utils";
+import {bytesToReadable, firstTextChild, isBetween, percentToDecimal, secondsToReadable, typeToString} from "../utils";
 import {booleanOptions, OptionKey, stringOptions} from "../settings/general";
 import {StashQuery, StashQueryClass} from "./stashQuery";
 import tippy, {ReferenceElement} from "tippy.js";
 
 /**
- * find existing symbol span recursively, undefined if none available
+ * Find existing symbol span recursively, undefined if none available
  */
 function getExistingSymbol(element: Element): HTMLSpanElement | undefined {
     if (element.getAttribute("data-type") === "stash-symbol") {
@@ -27,6 +27,51 @@ function getExistingSymbol(element: Element): HTMLSpanElement | undefined {
             .map(getExistingSymbol)
             .find(n => n);  // first truthy
     }
+}
+
+/**
+ * Find the closest image of the element at siblings or parents
+ */
+function getClosestImageElement(element: Element): HTMLImageElement | undefined {
+    let currentElement: Element | null = element;
+
+    function checkSiblings(element: Element): HTMLImageElement | undefined {
+        let sibling: Element | null = element.previousElementSibling as Element | null;
+
+        while (sibling) {
+            const img = sibling.querySelector('img');
+            if (img) {
+                return img as HTMLImageElement;
+            }
+            sibling = sibling.previousElementSibling as Element | null;
+        }
+
+        sibling = element.nextElementSibling as Element | null;
+        while (sibling) {
+            const img = sibling.querySelector('img');
+            if (img) {
+                return img as HTMLImageElement;
+            }
+            sibling = sibling.nextElementSibling as Element | null;
+        }
+
+        return undefined;
+    }
+
+    while (currentElement) {
+        const imgInCurrent = currentElement.querySelector('img');
+        if (imgInCurrent) {
+            return imgInCurrent as HTMLImageElement;
+        }
+
+        const imgInSiblings = checkSiblings(currentElement);
+        if (imgInSiblings) {
+            return imgInSiblings as HTMLImageElement;
+        }
+
+        currentElement = currentElement.parentElement;
+    }
+    return undefined;
 }
 
 export function clearSymbols() {
@@ -137,7 +182,7 @@ function stashSymbol(): HTMLSpanElement {
 
 /**
  * Prepends depending on the data the checkmark or cross to the selected element.
- * Also populates tooltip window.
+ * Also populates tooltip window and sets the opacity of the scene covers based on user settings (optional).
  */
 export function prefixSymbol(
     element: Element,
@@ -223,4 +268,27 @@ export function prefixSymbol(
     tooltipWindow.innerHTML = tooltip;
     tooltipWindow.tabIndex = 0;
     (symbol as ReferenceElement)._tippy?.setContent(tooltipWindow);
+
+    // Set opacity of scene cover if functionality is enabled
+    if ((target === Target.Scene) && (booleanOptions.get(OptionKey.opacityScenes) ?? false)) {
+
+        let opacityCheckMarkValue = parseInt(stringOptions.get(OptionKey.opacityCheckMark) ?? '-1');
+        let opacityCrossMarkValue = parseInt(stringOptions.get(OptionKey.opacityCrossMark) ?? '-1');
+
+        let symbolDataSymbol = symbol.getAttribute("data-symbol");
+
+        if (symbolDataSymbol === StashSymbol.Check && isBetween(opacityCheckMarkValue, 1, 99)) {
+            let img = getClosestImageElement(element);
+            if (img) {
+                img.style.opacity = percentToDecimal(opacityCheckMarkValue, 1).toFixed(1);
+            }
+        }
+
+        if (symbolDataSymbol === StashSymbol.Cross && isBetween(opacityCrossMarkValue, 1, 99)) {
+            let img = getClosestImageElement(element);
+            if (img) {
+                img.style.opacity = percentToDecimal(opacityCrossMarkValue, 1).toFixed(1);
+            }
+        }
+    }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,6 +96,32 @@ export function titleCase(text: string): string {
     return text.split(" ").map(n => capitalized(n)).join(" ");
 }
 
+export function isBetween(value: number | undefined | null, min: number, max: number): boolean {
+    if (value === undefined || value === null) {
+        return false;
+    }
+    return value >= min && value <= max;
+}
+
+export function percentToDecimal(percent: number | undefined | null, defaultValue: number): number {
+    if (percent == null || isNaN(percent)) {
+        return defaultValue;
+    }
+    return percent / 100;
+}
+
+export function range(first: number, last: number, step: number): number[] {
+    const rangeArray: number[] = [];
+    for (let i = first; i <= last; i += step) {
+        rangeArray.push(i);
+    }
+    return rangeArray;
+}
+
+export function rangeStr(first: number, last: number, step: number): string[] {
+    return range(first, last, step).map(number => number.toString());
+}
+
 export function nakedDomain(url: string): string {
     const regex = /^(https?:\/\/)?(www\.)?/i;
     return url.replace(regex, '');


### PR DESCRIPTION
* Add visual effect for scene covers based on opacity value in user settings
* Add scene settings for opacity with select menu and add global switch for modifying opacity

Solves #34 

Reworked PR from #48 

Added select menu for opacity values and global switch for enabling/disabling opacity functionality.
Note: When it was enabled and changed img opacity, open settings and disabled again the opacity changes stays. Page reload required. Otherwise the value needs to be stored and compared if there is a change to set back the opacity to 100%. I think this is negligible.