### PR TITLE
Add shift middleware to prevent tooltip horizontal overflow

### DIFF
--- a/src/tooltip/tooltipElement.ts
+++ b/src/tooltip/tooltipElement.ts
@@ -1,5 +1,5 @@
 
-import {computePosition, ComputePositionConfig, flip, offset} from "@floating-ui/dom";
+import {computePosition, ComputePositionConfig, flip, offset, shift} from "@floating-ui/dom";
 import {createDiv} from "../htmlHelper";
 
 const tooltipWindowId = "stashChecker-tooltipWindow";
@@ -56,7 +56,8 @@ function displayTooltip(stashSymbol: HTMLElement, tooltipWindow: HTMLElement) {
     let config: ComputePositionConfig = {
         placement: 'top',
         strategy: 'absolute',
-        middleware: [flip(), offset(10)]
+        middleware: [flip(), offset(10), shift({padding: 5})]
+
     }
     computePosition(stashSymbol, tooltipWindow, config).then(({x, y}) => {
         tooltipWindow.style.left = `${x}px`


### PR DESCRIPTION
Added shift() middleware to tooltip positioning to automatically adjust tooltips that would appear off-screen horizontally. Configured with 5px padding for screen edge spacing.

Before
<img width="315" height="160" alt="image" src="https://github.com/user-attachments/assets/c6d48835-9501-4633-ba4a-faa1597f138b" />
After
<img width="256" height="163" alt="image" src="https://github.com/user-attachments/assets/1252cc41-fa7a-4640-9e2f-8a698a3326f0" />
