### PR TITLE
Add alias matching

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -66,6 +66,12 @@ async function queryStash(
         case Type.Url:
             filter = `${type}:{value:"""${encodeURIComponent(queryString)}""",modifier:INCLUDES}${customFilter}`;
             break;
+        case Type.Name:
+            filter = `${type}:{value:"""${encodeURIComponent(queryString)}""",modifier:EQUALS}${customFilter}`;
+            if (target != Target.Movie) {
+                filter += `OR:{aliases:{value:"""${encodeURIComponent(queryString)}""",modifier:EQUALS}}`;
+            }
+            break;
         default:
             filter = `${type}:{value:"""${encodeURIComponent(queryString)}""",modifier:EQUALS}${customFilter}`;
             break;


### PR DESCRIPTION
This change makes it possible to use aliases when searching for performer and studio names. It’s especially useful when a Stash instance primarily collects data in English while keeping the original names as aliases.